### PR TITLE
Add `check-coupled-files` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ task(logger, { githubClient }) //this task will run once and script will end.
 
 * [`add-labels`](./docs/add-labels.md)
 * [`add-jira-link`](./docs/add-jira-link.md)
+* [`check-coupled-files`](./docs/check-coupled-files.md)
 * [`auto-merge-pull-request`](./docs/auto-merge-pull-request.md)
 * [`ping-old-pull-requests`](./docs/ping-old-pull-requests.md)

--- a/docs/check-coupled-files.md
+++ b/docs/check-coupled-files.md
@@ -1,0 +1,22 @@
+# Task `check-coupled-files`
+
+### What does it do?
+
+For each opened pull request it checks, whether files that usually should be changed in one changeset are actually changed.
+Think for example - whenever `package.json` changes, `package-lock.json`, should also be changed.
+If it detects missing change in one of fileset, it's reported in form of comment under pull request.
+
+### Should it be used as a hook or cron?
+
+Hook for `pull_request` event.
+
+### What dependencies are needed?
+
+* `githubClient` - already authenticated instance of npm's [github](https://www.npmjs.com/package/github)
+* `fileSets` - array of filesets to check. Each fileset is an array. Example:
+```javascript
+    const fileSets = [
+        [ 'deps.json', 'deps.lock' ], // checked separately from second fileset
+        [ 'README.md', 'docs/README.html', 'docs/README.pdf' ]
+    ];
+```

--- a/tasks/check-coupled-files.js
+++ b/tasks/check-coupled-files.js
@@ -10,9 +10,10 @@ function validateAction(payload) {
 }
 
 function getChangedFiles(githubClient, githubParams) {
+    const extractFilenames = R.pipe(R.prop('data'), R.map(R.prop('filename')));
+
     return githubClient.pullRequests.getFiles(githubParams)
-        .then(R.prop('data'))
-        .then(R.map(R.prop('filename')));
+        .then(extractFilenames);
 }
 
 function detectMissingFiles(fileSet, changedFiles) {

--- a/tasks/check-coupled-files.js
+++ b/tasks/check-coupled-files.js
@@ -17,12 +17,18 @@ function getPullRequestFileChanges(githubClient, githubParams) {
 }
 
 function detectMissingFiles(fileSets, pullRequestFileChanges) {
-    return fileSets.map((fileSet) => {
+    const buildMissingFilesPair = (fileSet) => {
         return {
             fileSet,
             missingFileChanges: R.without(pullRequestFileChanges, fileSet)
         };
-    });
+    };
+
+    const missingFiles = fileSets
+        .map(buildMissingFilesPair)
+        .filter((missingFilesPair) => missingFilesPair.missingFileChanges.length > 0);
+
+    return missingFiles.length > 0 ? missingFiles : Promise.reject(Cancel);
 }
 
 function postComment(githubClient, githubParams, missingFiles) {

--- a/tasks/check-coupled-files.js
+++ b/tasks/check-coupled-files.js
@@ -21,21 +21,21 @@ function detectMissingFiles(fileSets, pullRequestFileChanges) {
         return {
             fileSet,
             missingFileChanges: R.without(pullRequestFileChanges, fileSet)
-        }
+        };
     });
 }
 
 function postComment(githubClient, githubParams, missingFiles) {
     const buildFileSetMessageBulletPoint = (missingFilesPair) => {
-        const fileSetsList = '`[' + missingFilesPair.fileSet.join(', ') + ']`';
-        const missingFiles = '`[' + missingFilesPair.missingFileChanges.join(', ') + ']`';
+        const fileSetsList = `\`[${ missingFilesPair.fileSet.join(', ') }]\``;
+        const missingFiles = `\`[${ missingFilesPair.missingFileChanges.join(', ') }]\``;
 
-        return `* in ${fileSetsList} set there no change in these files: ${missingFiles}`;
+        return `* in ${fileSetsList} set there no change in these files: ${missingFiles}\n`;
     };
 
-    const body = `Usually these filesets are changed together, but I detected some missing changes:\n\n`
-        + missingFiles.map(buildFileSetMessageBulletPoint) +
-        `\n\nPlease make sure that you didn't forget about something. If everything is all right, then sorry, my bad!`
+    const body = `Usually these filesets are changed together, but I detected some missing changes:\n\n${
+        missingFiles.map(buildFileSetMessageBulletPoint).join('')
+    }\nPlease make sure that you didn't forget about something. If everything is all right, then sorry, my bad!`;
 
     return githubClient.issues.createComment(R.merge(githubParams, { body }));
 }

--- a/tasks/check-coupled-files.js
+++ b/tasks/check-coupled-files.js
@@ -20,13 +20,12 @@ function detectMissingFiles(fileSet, changedFiles) {
 }
 
 function postComment(githubClient, githubParams, fileSet, missingFiles) {
-    const wrapWithCodeMarkup = (str) => `\`${ str }\``;
-    const fileSetList = fileSet.map(wrapWithCodeMarkup).join(', ');
-    const missingFilesList = missingFiles.map(wrapWithCodeMarkup).join(', ');
+    const fileSetList = '`[' + fileSet.join(', ') + ']`';
+    const missingFilesList = '`[' + missingFiles.join(', ') + ']`';
 
-    const body = `Usually these files: ${fileSetList} are changed together in one changeset.\n` +
-        `However, in this pull request these files are not changed: ${missingFilesList}.\n` +
-        'Please make sure that you didn\'t forget about something. If everything is all right, then sorry, my bad!';
+    const body = `Usually these filesets are changed together, but I detected some missing changes:\n\n` +
+        `* in ${fileSetList} set there no change in these files: ${missingFilesList}\n\n` +
+        `Please make sure that you didn't forget about something. If everything is all right, then sorry, my bad!`
 
     return githubClient.issues.createComment(R.merge(githubParams, { body }));
 }

--- a/tasks/check-coupled-files.js
+++ b/tasks/check-coupled-files.js
@@ -1,0 +1,40 @@
+const R = require('ramda');
+
+function getChangedFiles(githubClient, githubParams) {
+    return githubClient.pullRequests.getFiles(githubParams)
+        .then(R.prop('data'))
+        .then(R.map(R.prop('filename')));
+}
+
+function detectMissingFiles(fileSet, changedFiles) {
+    return R.without(changedFiles, fileSet);
+}
+
+function postComment(githubClient, githubParams, fileSet, missingFiles) {
+    const wrapWithCodeMarkup = (str) => `\`${ str }\``;
+    const fileSetList = fileSet.map(wrapWithCodeMarkup).join(', ');
+    const missingFilesList = missingFiles.map(wrapWithCodeMarkup).join(', ');
+
+    const body = `Usually these files: ${fileSetList} are changed together in one changeset.\n` +
+        `However, in this pull request these files are not changed: ${missingFilesList}.\n` +
+        'Please make sure that you didn\'t forget about something. If everything is all right, then sorry, my bad!';
+
+    return githubClient.issues.createComment(R.merge(githubParams, { body }));
+}
+
+function logMessage(logger, githubParams) {
+    logger.log(`Posted info under pull request ${githubParams.owner}/${githubParams.repo}#${githubParams.number}`);
+}
+
+module.exports = function checkCoupledFiles(logger, { githubClient, fileSet }, payload) {
+    const githubParams = {
+        number: payload.number,
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name
+    };
+
+    return getChangedFiles(githubClient, githubParams)
+        .then(detectMissingFiles.bind(null, fileSet))
+        .then(postComment.bind(null, githubClient, githubParams, fileSet))
+        .then(logMessage.bind(null, logger, githubParams));
+};

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -44,15 +44,10 @@ describe('task check-coupled-files', () => {
                 repo: 'bar',
                 number: 123,
                 body: 'Usually these filesets are changed together, but I detected some missing changes:\n\n' +
-                      '* In `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
+                      '* in `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
                        'Please make sure that you didn\'t forget about something. ' +
                        'If everything is all right, then sorry, my bad!'
             });
-
-            console.log('Usually these filesets are changed together, but I detected some missing changes:\n\n' +
-            '* in `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
-             'Please make sure that you didn\'t forget about something. ' +
-             'If everything is all right, then sorry, my bad!');
 
             expect(logger.log).to.have.been.calledWithExactly('Posted info under pull request foo/bar#123');
         });

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -4,18 +4,19 @@ const sinon = require('sinon');
 const checkCoupledFiles = require('../../tasks/check-coupled-files');
 
 describe('task check-coupled-files', () => {
-    it('should detect non-changed files', function () {
-        const logger = { log: sinon.spy() };
-        const payload = {
-            number: 123,
-            repository: {
-                name: 'bar',
-                owner: {
-                    login: 'foo'
-                }
+    const defaultPayload = {
+        number: 123,
+        action: 'opened',
+        repository: {
+            name: 'bar',
+            owner: {
+                login: 'foo'
             }
-        };
-        const githubClient = {
+        }
+    };
+
+    function createGithubClient() {
+        return {
             pullRequests: {
                 getFiles: sinon.stub().resolves({
                     data: [ { filename: 'deps.json' }, { filename: 'README.md.txt' } ]
@@ -25,8 +26,13 @@ describe('task check-coupled-files', () => {
                 createComment: sinon.stub().resolves()
             }
         };
+    }
 
-        checkCoupledFiles(logger, { githubClient, fileSet: [ 'deps.json', 'deps.lock' ] }, payload).then(() => {
+    it('should detect non-changed files', function () {
+        const logger = { log: sinon.spy() };
+        const githubClient = createGithubClient();
+
+        checkCoupledFiles(logger, { githubClient, fileSet: [ 'deps.json', 'deps.lock' ] }, defaultPayload).then(() => {
             expect(githubClient.pullRequests.getFiles).to.have.been.calledWithExactly({
                 owner: 'foo',
                 repo: 'bar',
@@ -45,5 +51,23 @@ describe('task check-coupled-files', () => {
 
             expect(logger.log).to.have.been.calledWithExactly('Posted info under pull request foo/bar#123');
         });
+    });
+
+    it('should perform check link only for opened pull requests', () => {
+        const ignoredActions = [ 'assigned', 'unassigned', 'labeled', 'unlabeled', 'edited', 'closed', 'reopened' ];
+        const createTestCaseForAction = (action) => {
+            const logger = { log: sinon.spy() };
+            const githubClient = createGithubClient();
+            const payload = Object.assign({}, defaultPayload, { action });
+
+            return checkCoupledFiles(logger, { githubClient, fileSet: [] }, payload)
+                .then(() => {
+                    expect(githubClient.pullRequests.getFiles).not.to.have.been.called;
+                    expect(githubClient.issues.createComment).not.to.have.been.called;
+                    expect(logger.log).not.to.have.been.called;
+                });
+        };
+
+        return Promise.all(ignoredActions.map(createTestCaseForAction));
     });
 });

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -26,35 +26,6 @@ describe('task check-coupled-files', () => {
         };
     }
 
-    it('should detect non-changed files', function () {
-        const logger = { log: sinon.spy() };
-        const githubClient = createGithubClient();
-        githubClient.pullRequests.getFiles.resolves({ data:
-            [ { filename: 'deps.json' }, { filename: 'README.md' } ]
-        });
-        const fileSets = [ [ 'deps.json', 'deps.lock' ] ];
-
-        checkCoupledFiles(logger, { githubClient, fileSets }, defaultPayload).then(() => {
-            expect(githubClient.pullRequests.getFiles).to.have.been.calledWithExactly({
-                owner: 'foo',
-                repo: 'bar',
-                number: 123
-            });
-
-            expect(githubClient.issues.createComment).to.have.been.calledWithExactly({
-                owner: 'foo',
-                repo: 'bar',
-                number: 123,
-                body: 'Usually these filesets are changed together, but I detected some missing changes:\n\n' +
-                      '* in `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
-                       'Please make sure that you didn\'t forget about something. ' +
-                       'If everything is all right, then sorry, my bad!'
-            });
-
-            expect(logger.log).to.have.been.calledWithExactly('Posted info under pull request foo/bar#123');
-        });
-    });
-
     it('should detect changes in multiple filesets', function () {
         const logger = { log: sinon.spy() };
         const githubClient = createGithubClient();

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -43,11 +43,16 @@ describe('task check-coupled-files', () => {
                 owner: 'foo',
                 repo: 'bar',
                 number: 123,
-                body: 'Usually these files: `deps.json`, `deps.lock` are changed together in one changeset.\n' +
-                      'However, in this pull request these files are not changed: `deps.lock`.\n' +
-                      'Please make sure that you didn\'t forget about something. ' +
-                      'If everything is all right, then sorry, my bad!'
+                body: 'Usually these filesets are changed together, but I detected some missing changes:\n\n' +
+                      '* In `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
+                       'Please make sure that you didn\'t forget about something. ' +
+                       'If everything is all right, then sorry, my bad!'
             });
+
+            console.log('Usually these filesets are changed together, but I detected some missing changes:\n\n' +
+            '* in `[deps.json, deps.lock]` set there no change in these files: `[deps.lock]`\n\n' +
+             'Please make sure that you didn\'t forget about something. ' +
+             'If everything is all right, then sorry, my bad!');
 
             expect(logger.log).to.have.been.calledWithExactly('Posted info under pull request foo/bar#123');
         });

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -61,6 +61,24 @@ describe('task check-coupled-files', () => {
         });
     });
 
+    it('should not post a comment if there\'s no missing files', function () {
+        const logger = { log: sinon.spy() };
+        const githubClient = createGithubClient();
+        githubClient.pullRequests.getFiles.resolves({ data: [
+            { filename: 'deps.json' },
+            { filename: 'deps.lock' }
+        ] });
+        const fileSets = [
+            [ 'deps.json', 'deps.lock' ]
+        ];
+
+        checkCoupledFiles(logger, { githubClient, fileSets }, defaultPayload).then(() => {
+            expect(githubClient.pullRequests.getFiles).to.have.been.called;
+            expect(githubClient.issues.createComment).not.to.have.been.called;
+            expect(logger.log).not.to.have.been.called;
+        });
+    });
+
     it('should perform check link only for opened pull requests', () => {
         const ignoredActions = [ 'assigned', 'unassigned', 'labeled', 'unlabeled', 'edited', 'closed', 'reopened' ];
         const createTestCaseForAction = (action) => {

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -1,0 +1,49 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const checkCoupledFiles = require('../../tasks/check-coupled-files');
+
+describe('task check-coupled-files', () => {
+    it('should detect non-changed files', function () {
+        const logger = { log: sinon.spy() };
+        const payload = {
+            number: 123,
+            repository: {
+                name: 'bar',
+                owner: {
+                    login: 'foo'
+                }
+            }
+        };
+        const githubClient = {
+            pullRequests: {
+                getFiles: sinon.stub().resolves({
+                    data: [ { filename: 'deps.json' }, { filename: 'README.md.txt' } ]
+                })
+            },
+            issues: {
+                createComment: sinon.stub().resolves()
+            }
+        };
+
+        checkCoupledFiles(logger, { githubClient, fileSet: [ 'deps.json', 'deps.lock' ] }, payload).then(() => {
+            expect(githubClient.pullRequests.getFiles).to.have.been.calledWithExactly({
+                owner: 'foo',
+                repo: 'bar',
+                number: 123
+            });
+
+            expect(githubClient.issues.createComment).to.have.been.calledWithExactly({
+                owner: 'foo',
+                repo: 'bar',
+                number: 123,
+                body: 'Usually these files: `deps.json`, `deps.lock` are changed together in one changeset.\n' +
+                      'However, in this pull request these files are not changed: `deps.lock`.\n' +
+                      'Please make sure that you didn\'t forget about something. ' +
+                      'If everything is all right, then sorry, my bad!'
+            });
+
+            expect(logger.log).to.have.been.calledWithExactly('Posted info under pull request foo/bar#123');
+        });
+    });
+});

--- a/tests/tasks/check-coupled-files-spec.js
+++ b/tests/tasks/check-coupled-files-spec.js
@@ -32,7 +32,7 @@ describe('task check-coupled-files', () => {
         const logger = { log: sinon.spy() };
         const githubClient = createGithubClient();
 
-        checkCoupledFiles(logger, { githubClient, fileSet: [ 'deps.json', 'deps.lock' ] }, defaultPayload).then(() => {
+        checkCoupledFiles(logger, { githubClient, fileSets: [ [ 'deps.json', 'deps.lock' ] ] }, defaultPayload).then(() => {
             expect(githubClient.pullRequests.getFiles).to.have.been.calledWithExactly({
                 owner: 'foo',
                 repo: 'bar',
@@ -60,7 +60,7 @@ describe('task check-coupled-files', () => {
             const githubClient = createGithubClient();
             const payload = Object.assign({}, defaultPayload, { action });
 
-            return checkCoupledFiles(logger, { githubClient, fileSet: [] }, payload)
+            return checkCoupledFiles(logger, { githubClient, fileSets: [] }, payload)
                 .then(() => {
                     expect(githubClient.pullRequests.getFiles).not.to.have.been.called;
                     expect(githubClient.issues.createComment).not.to.have.been.called;


### PR DESCRIPTION
# Task `check-coupled-files`

### What does it do?

For each opened pull request it checks, whether files that usually should be changed in one changeset are actually changed.
Think for example - whenever `package.json` changes, `package-lock.json`, should also be changed.
If it detects missing change in one of fileset, it's reported in form of comment under pull request.

### Should it be used as a hook or cron?

Hook for `pull_request` event.

### What dependencies are needed?

* `githubClient` - already authenticated instance of npm's [github](https://www.npmjs.com/package/github)
* `fileSets` - array of filesets to check. Each fileset is an array. Example:
```javascript
    const fileSets = [
        [ 'deps.json', 'deps.lock' ], // checked separately from second fileset
        [ 'README.md', 'docs/README.html', 'docs/README.pdf' ]
    ];
```
